### PR TITLE
intToHex encodes data incorrectly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -28,7 +28,7 @@ function padToEven(value) {
 function intToHex(i) {
   var hex = i.toString(16); // eslint-disable-line
 
-  return `0x${padToEven(hex)}`;
+  return `0x${hex}`;
 }
 
 /**

--- a/src/tests/test.index.js
+++ b/src/tests/test.index.js
@@ -25,7 +25,7 @@ describe('check all exports', () => {
   });
 
   it('should convert intToHex', () => {
-    assert.equal(util.intToHex(new BN(0)), '0x00');
+    assert.equal(util.intToHex(new BN(0)), '0x0');
   });
 
   it('should throw when invalid abi', () => {


### PR DESCRIPTION
Fixes issues #6 by removing the call to padToEven